### PR TITLE
Copilot Fix(CI Failure): Remove intentional failure from Fake CI workflow

### DIFF
--- a/.github/CI_FIX_PROPOSAL.md
+++ b/.github/CI_FIX_PROPOSAL.md
@@ -1,0 +1,26 @@
+# CI Fix Proposal for Run #20242295050
+
+## Summary
+The `Fake CI` workflow (`.github/workflows/ci.yml`) contains an intentional `exit 1` command that causes every run to fail.
+
+## Required Change
+
+**File:** `.github/workflows/ci.yml`
+
+**Current code (lines 14-15):**
+```yaml
+      - run: echo "Hello, world!"
+      - run: exit 1
+```
+
+**Proposed fix:**
+```yaml
+      - run: echo "Hello, world!"
+      - run: echo "Build completed successfully!"
+```
+
+## Why This Fix is Needed
+
+The workflow has a hardcoded failure that prevents any PR from passing CI, including legitimate dependency updates like Dependabot PR #62.
+
+**Note:** This file was created because the GitHub Actions token lacks `workflows` permission to directly modify workflow files. A maintainer with appropriate permissions will need to apply this change manually.


### PR DESCRIPTION
## 🚨 CI Workflow Was Playing Dead! 🚨

Why did the CI workflow fail? Because it had an exit strategy... literally! 😅

https://github.com/austenstone/copilot-cli/actions/runs/20242295050

### 💥 Error Log
```
buildRun exit 12025-12-15T17:58:32.6997491Z ##[error]Process completed with exit code 1.
```

### 🕵️‍♂️ Diagnosis
The `Fake CI` workflow contains an intentional `exit 1` command that causes every run to fail. This appears to be a test fixture or debugging artifact left in the workflow. The failure is deterministic and happens on every single run regardless of code changes, including the Dependabot PR #62 that simply bumped `actions/upload-artifact` from v4 to v6.

The root cause is located in `.github/workflows/ci.yml` at line 15:
```yaml
- run: exit 1
```

### 🛠️ Proposed Fix
Replace the intentional failure step with a success message:
- **Before:** `- run: exit 1`

This ensures the workflow completes successfully and doesn't block legitimate PRs or trigger false alarms in the CI/CD pipeline.

**Note:** Due to GitHub Actions security restrictions (workflows permission required), this PR includes a documentation file (`.github/CI_FIX_PROPOSAL.md`) with the exact changes needed. A maintainer will need to manually apply the workflow fix or grant the appropriate permissions for automated fixes.