### PR TITLE
fix: correct Copilot CLI config surface and default to stable channel

### DIFF
--- a/.github/workflows/test-copilot.yml
+++ b/.github/workflows/test-copilot.yml
@@ -11,8 +11,9 @@ on:
       - action.yml
       - .github/workflows/test-copilot.yml
   schedule:
-    # Nightly drift check — the action installs @github/copilot@prerelease at
-    # runtime, so this is the only thing that catches a breaking CLI release.
+    # Nightly drift check — the prerelease-drift job installs @github/copilot@prerelease,
+    # so this is the only thing that catches a breaking CLI release before it reaches
+    # the stable `latest` channel that consumers get by default.
     - cron: '0 7 * * *'
   workflow_dispatch:
 
@@ -39,6 +40,21 @@ jobs:
         run: |
           echo "Exit code: ${{ steps.copilot.outputs.exit-code }}"
           test "${{ steps.copilot.outputs.exit-code }}" = "0"
+
+  # Early warning for breaking changes in the prerelease CLI channel.
+  # The action defaults to `latest`, so this is what catches drift before consumers hit it.
+  prerelease-drift:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: ./
+        id: copilot
+        with:
+          prompt: "Say 'prerelease works' and nothing else."
+          copilot-version: prerelease
+          max-turns: 1
+      - name: Verify exit code output
+        run: test "${{ steps.copilot.outputs.exit-code }}" = "0"
 
   # Test autopilot + max-turns limit with tool use
   autopilot:
@@ -203,22 +219,31 @@ jobs:
           echo "Exit code: ${{ steps.copilot.outputs.exit-code }}"
           echo "Step outcome: ${{ steps.copilot.outcome }}"
 
-  # Test copilot-config is applied
+  # Test copilot-config is merged into settings.json
   config:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
+      - name: Seed a pre-existing user setting
+        run: |
+          mkdir -p ~/.copilot
+          echo '{"beep":true}' > ~/.copilot/settings.json
       - uses: ./
         with:
           prompt: "Say 'config test passed'."
           copilot-config: |
             {
               "banner": "never",
-              "render_markdown": false,
-              "theme": "dark",
-              "trusted_folders": []
+              "renderMarkdown": false,
+              "theme": "dim"
             }
           max-turns: 1
+      - name: Verify settings.json merged without clobbering
+        run: |
+          cat ~/.copilot/settings.json
+          test "$(jq -r '.theme' ~/.copilot/settings.json)" = "dim"
+          test "$(jq -r '.renderMarkdown' ~/.copilot/settings.json)" = "false"
+          test "$(jq -r '.beep' ~/.copilot/settings.json)" = "true"
 
   # Test long context window selection
   context:

--- a/.github/workflows/test-copilot.yml
+++ b/.github/workflows/test-copilot.yml
@@ -56,6 +56,39 @@ jobs:
       - name: Verify exit code output
         run: test "${{ steps.copilot.outputs.exit-code }}" = "0"
 
+  # Ranges contain '>' which shell-redirects if the npm spec isn't quoted.
+  version-spec:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: ./
+        id: copilot
+        with:
+          prompt: "Say 'version spec works' and nothing else."
+          copilot-version: '>=1.0.80'
+          max-turns: 1
+      - name: Verify exit code output
+        run: test "${{ steps.copilot.outputs.exit-code }}" = "0"
+
+  # The default copilot-version is pinned for reproducibility, so it needs a nudge
+  # when it falls behind. Only fails on the nightly schedule so PRs aren't blocked
+  # every time the CLI ships.
+  version-pin-drift:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - name: Compare pinned default against registry latest
+        run: |
+          PINNED=$(python3 -c "import yaml;print(yaml.safe_load(open('action.yml'))['inputs']['copilot-version']['default'])")
+          LATEST=$(npm view --registry=https://registry.npmjs.org '@github/copilot@latest' version)
+          echo "pinned=\`$PINNED\` latest=\`$LATEST\`" >> "$GITHUB_STEP_SUMMARY"
+          if [ "$PINNED" = "$LATEST" ]; then
+            echo "Pinned default is current ($PINNED)."
+            exit 0
+          fi
+          echo "::warning::copilot-version default is pinned to $PINNED but @latest is $LATEST"
+          test "${{ github.event_name }}" != "schedule"
+
   # Test autopilot + max-turns limit with tool use
   autopilot:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-copilot.yml
+++ b/.github/workflows/test-copilot.yml
@@ -278,6 +278,37 @@ jobs:
           test "$(jq -r '.renderMarkdown' ~/.copilot/settings.json)" = "false"
           test "$(jq -r '.beep' ~/.copilot/settings.json)" = "true"
 
+  # Pre-1.0.35 CLIs never read settings.json, so config must land in config.json
+  config-legacy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: ./
+        with:
+          prompt: "Say 'legacy config test passed'."
+          copilot-version: '1.0.34'
+          copilot-config: '{"banner":"never"}'
+          max-turns: 1
+      - name: Verify config landed in config.json, not settings.json
+        run: |
+          test "$(jq -r '.banner' ~/.copilot/config.json)" = "never"
+          test ! -s ~/.copilot/settings.json
+
+  # Invalid copilot-config must fail fast rather than silently no-op
+  config-invalid:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - id: bad
+        continue-on-error: true
+        uses: ./
+        with:
+          prompt: "Should never run."
+          copilot-config: '{not valid json'
+          max-turns: 1
+      - name: Verify the action rejected it
+        run: test "${{ steps.bad.outcome }}" = "failure"
+
   # Test long context window selection
   context:
     runs-on: ubuntu-latest

--- a/action.yml
+++ b/action.yml
@@ -58,9 +58,9 @@ inputs:
     description: 'Comma-separated list of URLs or domains to deny (e.g., "evil.com")'
     required: false
   copilot-version:
-    description: 'Version of Copilot CLI to install (e.g., "latest", "prerelease", "1.0.80")'
+    description: 'Version spec of the Copilot CLI to install. Examples: 1.0.80, 1.x, >=1.0.80, latest, prerelease.'
     required: false
-    default: 'latest'
+    default: '1.0.80'
   model:
     description: 'Model to use (e.g., "claude-sonnet-4.6", "claude-opus-4.8", "gpt-5.5")'
     required: false
@@ -192,13 +192,9 @@ runs:
         # Script
 
         echo "::group::Install GitHub Copilot CLI"
-        if [ "$COPILOT_VERSION" = "latest" ]; then
-          npm install -g @github/copilot
-        elif [ "$COPILOT_VERSION" = "prerelease" ]; then
-          npm install -g @github/copilot@prerelease
-        else
-          npm install -g @github/copilot@$COPILOT_VERSION
-        fi
+        # Quoted so semver ranges (">=1.0.80") aren't parsed as shell redirection.
+        npm install -g "@github/copilot@$COPILOT_VERSION"
+        RESOLVED_VERSION=$(npm ls -g --depth 0 --json 2>/dev/null | jq -r '.dependencies["@github/copilot"].version // empty')
         echo "CLI Version: $(copilot --version)"
         echo "::endgroup::"
 

--- a/action.yml
+++ b/action.yml
@@ -19,14 +19,12 @@ inputs:
     description: 'MCP configuration for GitHub Copilot [Link](https://docs.github.com/en/copilot/how-tos/use-copilot-agents/coding-agent/extend-coding-agent-with-mcp#writing-a-json-configuration-for-mcp-servers)'
     required: false
   copilot-config:
-    description: 'Configuration for GitHub Copilot'
+    description: 'Configuration for GitHub Copilot, merged into ~/.copilot/settings.json'
     required: false
     default: |
       {
         "banner": "never",
-        "renderMarkdown": true,
-        "theme": "auto",
-        "trustedFolders": []
+        "renderMarkdown": true
       }
   autopilot:
     description: 'Enable autopilot continuation in prompt mode'
@@ -60,9 +58,9 @@ inputs:
     description: 'Comma-separated list of URLs or domains to deny (e.g., "evil.com")'
     required: false
   copilot-version:
-    description: 'Version of Copilot CLI to install (e.g., "latest", "prerelease", "1.0.63")'
+    description: 'Version of Copilot CLI to install (e.g., "latest", "prerelease", "1.0.80")'
     required: false
-    default: 'prerelease'
+    default: 'latest'
   model:
     description: 'Model to use (e.g., "claude-sonnet-4.6", "claude-opus-4.8", "gpt-5.5")'
     required: false
@@ -206,9 +204,16 @@ runs:
 
         if [ -n "$CONFIG" ]; then
           echo "::group::Configure Copilot"
-          mkdir -p $HOME/.copilot
-          echo "$CONFIG" > $HOME/.copilot/config.json
-          cat $HOME/.copilot/config.json
+          mkdir -p "$HOME/.copilot"
+          # User settings belong in settings.json. config.json is CLI-managed state
+          # (loggedInUsers, installedPlugins) and clobbering it breaks persistent runners.
+          SETTINGS="$HOME/.copilot/settings.json"
+          if [ -s "$SETTINGS" ]; then
+            jq -s '.[0] * .[1]' "$SETTINGS" - <<< "$CONFIG" > "$SETTINGS.tmp" && mv "$SETTINGS.tmp" "$SETTINGS"
+          else
+            jq '.' <<< "$CONFIG" > "$SETTINGS"
+          fi
+          cat "$SETTINGS"
           echo "::endgroup::"
         fi
         
@@ -472,7 +477,7 @@ runs:
         DISALLOW_TEMP_DIR: ${{ inputs.disallow-temp-dir }}
         PLUGIN_DIR: ${{ inputs.plugin-dir }}
     - name: Upload Copilot Artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       if: ${{ always() && inputs.upload-artifact == 'true' }}
       with:
         name: copilot-logs-${{ github.job }}-${{ github.run_id }}-${{ github.run_attempt }}

--- a/action.yml
+++ b/action.yml
@@ -194,22 +194,33 @@ runs:
         echo "::group::Install GitHub Copilot CLI"
         # Quoted so semver ranges (">=1.0.80") aren't parsed as shell redirection.
         npm install -g "@github/copilot@$COPILOT_VERSION"
-        RESOLVED_VERSION=$(npm ls -g --depth 0 --json 2>/dev/null | jq -r '.dependencies["@github/copilot"].version // empty')
+        CLI_VERSION=$(copilot --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.]+)?' | head -1)
         echo "CLI Version: $(copilot --version)"
         echo "::endgroup::"
 
         if [ -n "$CONFIG" ]; then
           echo "::group::Configure Copilot"
-          mkdir -p "$HOME/.copilot"
-          # User settings belong in settings.json. config.json is CLI-managed state
-          # (loggedInUsers, installedPlugins) and clobbering it breaks persistent runners.
-          SETTINGS="$HOME/.copilot/settings.json"
-          if [ -s "$SETTINGS" ]; then
-            jq -s '.[0] * .[1]' "$SETTINGS" - <<< "$CONFIG" > "$SETTINGS.tmp" && mv "$SETTINGS.tmp" "$SETTINGS"
-          else
-            jq '.' <<< "$CONFIG" > "$SETTINGS"
+          if ! jq -e . >/dev/null 2>&1 <<< "$CONFIG"; then
+            echo "::error::copilot-config is not valid JSON"
+            exit 1
           fi
-          cat "$SETTINGS"
+          mkdir -p "$HOME/.copilot"
+          # User settings moved out of config.json in CLI 1.0.35. Older pins never
+          # read settings.json, so write to whichever file this version actually reads.
+          SETTINGS_TARGET="$HOME/.copilot/settings.json"
+          if [ -n "$CLI_VERSION" ] && [ "$(printf '%s\n1.0.35\n' "$CLI_VERSION" | sort -V | head -1)" != "1.0.35" ]; then
+            SETTINGS_TARGET="$HOME/.copilot/config.json"
+            echo "::warning::Copilot CLI $CLI_VERSION predates settings.json (added in 1.0.35); writing copilot-config to config.json instead"
+          fi
+          if [ -s "$SETTINGS_TARGET" ]; then
+            # Newer config.json ships // comments, which jq cannot parse.
+            EXISTING=$(sed 's|^[[:space:]]*//.*$||' "$SETTINGS_TARGET")
+            jq -s '.[0] * .[1]' <(printf '%s' "${EXISTING:-\{\}}") - <<< "$CONFIG" > "$SETTINGS_TARGET.tmp" \
+              && mv "$SETTINGS_TARGET.tmp" "$SETTINGS_TARGET"
+          else
+            jq '.' <<< "$CONFIG" > "$SETTINGS_TARGET"
+          fi
+          cat "$SETTINGS_TARGET"
           echo "::endgroup::"
         fi
         


### PR DESCRIPTION
## What

Fixes three correctness problems in how the action talks to the Copilot CLI, plus a deprecated runtime.

### 1. Writing user settings to the wrong file (`config.json` → `settings.json`)

The action wrote `copilot-config` to `~/.copilot/config.json` and **overwrote** it. The CLI self-documents that file:

```
// User settings belong in settings.json.
// This file is managed automatically.
```

`config.json` holds CLI-managed state — `loggedInUsers`, `installedPlugins`, `firstLaunchAt`. On an ephemeral GitHub-hosted runner that's harmless, but on a **persistent or self-hosted runner it destroys the CLI's auth state**. Per the [config dir reference](https://docs.github.com/en/copilot/reference/copilot-cli-reference/cli-config-dir-reference), user settings were moved to `settings.json` and legacy `config.json` values are only auto-migrated on startup.

Now writes `settings.json` and **merges** rather than clobbers, so pre-existing runner settings survive.

### 2. Two invalid values in the default `copilot-config`

| Key | Problem |
|---|---|
| `"theme": "auto"` | `auto` is not in the theme enum (`default`, `github`, `dim`, `high-contrast`, `colorblind`) |
| `"trustedFolders": []` | Real key, but it lives in CLI-managed `config.json`, not `settings.json` — so it was silently ignored there. Directory trust is handled by `--add-dir`, which the action already passes. |

Docs state invalid values are ignored and surfaced as config problems. Both removed; `banner` and `renderMarkdown` are verified-valid and stay.

### 3. `copilot-version` defaulted to `prerelease`

Every consumer of this action was installing bleeding-edge CLI builds (currently `1.0.81-5`) instead of stable (`1.0.80`). One bad prerelease broke every downstream repo.

Default is now `latest`. Drift detection is **not** lost — a dedicated `prerelease-drift` job in the nightly matrix pins `copilot-version: prerelease`, so a breaking CLI release still gets caught here first, before it reaches consumers.

### 4. `actions/upload-artifact@v4` → `v7`

v4 targets Node 20. Every run currently logs:

> Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: `actions/upload-artifact@v4`

Reviewed v5/v6/v7 release notes — no breaking change for this usage (`archive` defaults to the old zip behavior; multi-path + `if-no-files-found` unchanged). v6+ needs runner ≥ 2.327.1; hosted runners are on 2.336.0. Supersedes #66.

## Testing

- `config` test job rewritten: it previously passed `render_markdown`, `theme: "dark"`, and `trusted_folders` — all invalid keys/values that asserted nothing. It now seeds a pre-existing setting, then asserts the action's config was merged in **and** the pre-existing key survived.
- Merge logic verified locally against both the empty and pre-populated cases.
- `bash -n` + `shellcheck` clean on the embedded script; YAML parses.

Verified against Copilot CLI `1.0.80` and the live docs. Separately confirmed all 44 flags the action passes still exist in the current CLI — no flag drift.


---

## Follow-up: version spec input + the `settings.json` cutover

Two more fixes landed on this branch after review.

### `copilot-version` now takes a version spec

It defaulted to `latest`, so every CLI release shipped straight into everyone's
workflows unreviewed. It now defaults to a pinned `1.0.80` and accepts any npm
spec — `1.0.80`, `1.x`, `>=1.0.80`, `latest`, `prerelease` — matching the
`node-version` convention from `actions/setup-node`.

This also fixed a latent bug: the install ran `npm install -g @github/copilot@$COPILOT_VERSION`
**unquoted**, so a range like `>=1.0.80` was parsed as shell redirection and
created a file named `=1.0.80` instead of installing anything. The `version-spec`
job is the regression test.

`version-pin-drift` fails **only** on the nightly schedule when the pinned
default falls behind `latest`, so PRs aren't blocked every time the CLI ships
but the pin can't silently rot either.

### `copilot-config` was silently dropped on older CLIs

User settings moved out of `config.json` into `settings.json` in CLI **1.0.35**
(2026-04-23). Writing to `settings.json` unconditionally meant anyone pinning
below that got their `copilot-config` **silently ignored**. The action now
resolves the installed version and writes to whichever file that CLI actually
reads, warning when it takes the legacy path.

Newer `config.json` files also open with `//` comments, which `jq` cannot parse,
so the legacy path strips them before merging. Invalid `copilot-config` JSON now
fails fast instead of no-opping.

New jobs: `config-legacy` (pins `1.0.34`, asserts `config.json`) and
`config-invalid` (asserts the action rejects malformed JSON).
