### PR TITLE
Upgrade straggler checkout refs and guard against action major drift

### DIFF
--- a/.github/workflows/test-copilot.yml
+++ b/.github/workflows/test-copilot.yml
@@ -62,7 +62,7 @@ jobs:
   version-spec:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
       - uses: ./
         id: copilot
         with:
@@ -78,7 +78,7 @@ jobs:
   version-pin-drift:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
       - name: Compare pinned default against registry latest
         run: |
           PINNED=$(python3 -c "import yaml;print(yaml.safe_load(open('action.yml'))['inputs']['copilot-version']['default'])")
@@ -298,7 +298,7 @@ jobs:
   config-legacy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
       - uses: ./
         with:
           prompt: "Say 'legacy config test passed'."
@@ -314,7 +314,7 @@ jobs:
   config-invalid:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
       - id: bad
         continue-on-error: true
         uses: ./
@@ -464,3 +464,23 @@ jobs:
           prompt: "Say 'readme example works'."
           max-turns: 1
           fail-on-error: true
+
+  # Newly added jobs have twice drifted onto stale action majors after a bulk
+  # upgrade, and a stale major silently reintroduces the Node 20 deprecation.
+  action-major-drift:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v7
+      - name: Fail on outdated first-party action majors
+        run: |
+          STALE=$(grep -rnoE 'uses: actions/(checkout|upload-artifact|setup-node)@v[0-9]+' .github/workflows \
+            | grep -vE 'checkout@v7|upload-artifact@v7|setup-node@v6' || true)
+          if [ -n "$STALE" ]; then
+            echo "::error::Outdated action majors found:"
+            echo "$STALE"
+            exit 1
+          fi
+          echo "All first-party action majors are current."


### PR DESCRIPTION
## What

Four `actions/checkout@v5` refs survived on `main` and are now `@v7`, plus a CI guard so this class of drift can't come back silently.

## Why

The `version-spec`, `version-pin-drift`, `config-legacy`, and `config-invalid` jobs were authored in #77 alongside the bulk `@v7` upgrade in #78. The two landed in parallel, so the new jobs never got swept — they shipped on `@v5`.

That matters beyond tidiness: a stale major silently reintroduces the Node 20 deprecation warning the upgrade existed to remove. A real regression wearing a green checkmark, which is the same failure shape as the labeler bug in #78.

## The guard

New `action-major-drift` job fails on any outdated first-party action major, scoped to `uses:` declarations specifically — an unscoped pattern matched the guard's own allowlist string and passed only by accident.

Verified in both directions:
- Current tree -> no matches, passes
- Injected `checkout@v5` -> correctly fails, reporting the offending file and line

## Result

`checkout@v5` refs: 4 -> 0. All 31 checkout refs on `@v7`, 32 jobs total.

Closes #50
Closes #66